### PR TITLE
Updates JDK to 1.8, Tomcat to 8.0.x, and adds GPG signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 rpmbuild/
 *.swp
+gpg-env

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 tomcat-rpm
 ==========
 
-This project defines a build system for building Apache Tomcat 7.0.x
+This project defines a build system for building Apache Tomcat 8.0.x
 source and binary RPM files. The included `build.sh` *must* be used to kick off
 the RPM building process. The SPEC file assumes various work is done by the
 script; e.g. the Tomcat packages being extracted and compiled in the corre
@@ -12,7 +12,7 @@ to be set according to the Java packages installed on the build system (and, in
 turn, the target install system[s]). That is, if you are using the community
 build Java packages, these variables will be set to "/usr/java/latest" and
 "jdk", respectively. If you are using the RedHat packages, like the
-java-1.7.0-oracle and java-1.7.0-oracle-devel packages, then they would be
+java-1.8.0-oracle and java-1.8.0-oracle-devel packages, then they would be
 set to "/usr/lib/jvm/java" and "java-sdk". The `build.sh` script does this
 for you.
 

--- a/build.sh
+++ b/build.sh
@@ -79,8 +79,26 @@ mv ${B:2} commons-daemon
 tar cf - commons-daemon | gzip -- - > commons-daemon-native.tar.gz
 rm -rf commons-daemon
 
-echo "Building RPM..."
-cd ${CWD}
-rpmbuild --define "_topdir ${CWD}/rpmbuild" --define "_java_home ${JHOME}" \
-  --define "_jdk_require ${JDKREQ}" -ba ${SPEC}
+if [ -f ${CWD}/gpg-env ]; then
+  echo "Building RPM with GPG signing..."
+  cd ${CWD}
+
+  source gpg-env
+  if [ "${gpg_bin}" != "" ]; then
+    rpmbuild --define "_topdir ${CWD}/rpmbuild" --define "_java_home ${JHOME}" \
+      --define "_jdk_require ${JDKREQ}" --define "_signature ${signature}" \
+      --define "_gpg_path ${gpg_path}" --define "_gpg_name ${gpg_name}" \
+      --define "__gpg ${gpg_bin}" --sign -ba ${SPEC}
+  else
+    rpmbuild --define "_topdir ${CWD}/rpmbuild" --define "_java_home ${JHOME}" \
+      --define "_jdk_require ${JDKREQ}" --define "_signature ${signature}" \
+      --define "_gpg_path ${gpg_path}" --define "_gpg_name ${gpg_name}" \
+      --sign --ba ${SPEC}
+  fi
+else
+  echo "Building RPM..."
+  cd ${CWD}
+  rpmbuild --define "_topdir ${CWD}/rpmbuild" --define "_java_home ${JHOME}" \
+    --define "_jdk_require ${JDKREQ}" -ba ${SPEC}
+fi
 

--- a/gpg-env.example
+++ b/gpg-env.example
@@ -1,0 +1,15 @@
+# Copy this file to 'gpg-env' and adjust the variable therein
+# to enable automatic GPG signing of the generate RPM.
+
+# Corresponds to RPM's `%_signature` macro
+signature='gpg'
+
+# Corresponds to RPM's `%_gpg_name` macro
+gpg_name='Foo User'
+
+# Corresponds to RPM's `%_gpg_path` macro
+gpg_path='~/.gnupg'
+
+# Corresponds to RPM's `%__gpg` macro
+# Uncomment if really needed. Otherwise it will not be set
+#gpg_bin='/usr/bin/gpg'

--- a/tomcat.spec
+++ b/tomcat.spec
@@ -1,6 +1,6 @@
 %define major_version 8
 %define minor_version 0
-%define micro_version 18
+%define micro_version 22
 %define appname tomcat
 %define distname %{name}-%{version}
 
@@ -217,6 +217,8 @@ fi
 
 
 %changelog
+* Mon May 18 2015 James Sumners <james.sumners@gmail.com> - 8.0.22%{?dist}
+- Updated Tomcat to version 8.0.22
 * Tue Feb 03 2015 James Sumners <james.sumners@gmail.com> - 8.0.18%{?dist}
 - Updated Tomcat to version 8.0.18
 * Fri Dec 19 2014 James Sumners <james.sumners@gmail.com> - 8.0.15%{?dist}

--- a/tomcat.spec
+++ b/tomcat.spec
@@ -1,6 +1,6 @@
-%define major_version 7
+%define major_version 8
 %define minor_version 0
-%define micro_version 52
+%define micro_version 15
 %define appname tomcat
 %define distname %{name}-%{version}
 
@@ -45,7 +45,7 @@ Requires: apr >= 0:1.1.29
 Requires: libtool
 Requires: libcap
 
-BuildRequires: %{_jdk_require} >= 1:1.7
+BuildRequires: %{_jdk_require} >= 1:1.8
 BuildRequires: apr-devel >= 0:1.1.29
 BuildRequires: openssl-devel >= 0:0.9.7
 BuildRequires: autoconf, libtool, doxygen
@@ -217,6 +217,8 @@ fi
 
 
 %changelog
+* Fri Dec 19 2014 James Sumners <james.sumners@gmail.com> - 8.0.15%{?dist}
+- Updated Tomcat to version 8.0.15
 * Wed Feb 19 2014 James Sumners <james.sumners@gmail.com> - 7.0.52%{?dist}
 - Updated Tomcat version to 7.0.52 (fixes CVE-2014-0050)
 * Mon Feb 03 2014 James Sumners <james.sumners@gmail.com> - 7.0.50%{?dist}

--- a/tomcat.spec
+++ b/tomcat.spec
@@ -1,6 +1,6 @@
 %define major_version 8
 %define minor_version 0
-%define micro_version 15
+%define micro_version 18
 %define appname tomcat
 %define distname %{name}-%{version}
 
@@ -217,6 +217,8 @@ fi
 
 
 %changelog
+* Tue Feb 03 2015 James Sumners <james.sumners@gmail.com> - 8.0.18%{?dist}
+- Updated Tomcat to version 8.0.18
 * Fri Dec 19 2014 James Sumners <james.sumners@gmail.com> - 8.0.15%{?dist}
 - Updated Tomcat to version 8.0.15
 * Wed Feb 19 2014 James Sumners <james.sumners@gmail.com> - 7.0.52%{?dist}


### PR DESCRIPTION
This pull request sets the required JDK to 1.8 and updates the Tomcat version to the 8.0.x series. It also provides a way to automatically GPG sign the generated RPMs based on the presence of a 'gpg-env' file.
